### PR TITLE
Square images

### DIFF
--- a/layout/base.ect
+++ b/layout/base.ect
@@ -12,5 +12,5 @@
 | Puesto   |  Usuario  |Contrib.| Stars | Lenguajes   |      Lugar      |  Avatar  |
 |----------|:---------:|-------:|-------|-------------|:---------------:|----------|
 <% for u in @usuarios : %>
-| <%- u.lugar %> | [<%- u.login %>](https://github.com/<%- u.login %>) | <%- u.contributions %> | <%- u.stars %> | <%- u.language %> | <%- u.location %> | <img src='<%- u.gravatar %>' width='64' height='64' title='<%- u.name %>'> |
+| <%- u.lugar %> | [<%- u.login %>](https://github.com/<%- u.login %>) | <%- u.contributions %> | <%- u.stars %> | <%- u.language %> | <%- u.location %> | <img src='<%- u.gravatar %>' title='<%- u.name %>'> |
 <% end %>


### PR DESCRIPTION
I oberved the strange shape of the user images (are rectangules).
![captura de pantalla de 2015-05-30 17 31 11](https://cloud.githubusercontent.com/assets/4806311/7898013/f343a246-06f2-11e5-8a3a-b517f31613a7.png)

If we go to the link of each image, we will see the image is square (same width and heigth).
Using the editor of Chrome, I removed the params "width" and "height" (because the image is not as bigger as 64px) and the result... (only the two first images)
![captura de pantalla de 2015-05-30 17 32 06](https://cloud.githubusercontent.com/assets/4806311/7898031/8838eb7c-06f3-11e5-8de6-92dd43325166.png)


I tried this in some devices